### PR TITLE
Fix SEO validation issues across posts and layout.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -263,6 +263,7 @@ ai_visible_content:
       - madmatvey
       - eugeneleontev
       - eugene
+      - nasuta
     knows_about:                             # Skills/topics (used for entity linking too)
       - Ruby on Rails
       - PostgreSQL

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 layout: compress
 ---
 
-<!doctype html>
+<!DOCTYPE html>
 
 {% include origin-type.html %}
 

--- a/_plugins/fix-ai-link-doctype-order.rb
+++ b/_plugins/fix-ai-link-doctype-order.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# jekyll-ai-visible-content prepends ai:* link tags when a page has no </head>
+# (e.g. jekyll-redirect-from stubs), which pushes DOCTYPE off the first line.
+module FixAiLinkDoctypeOrder
+  module_function
+
+  def fix!(doc)
+    return unless doc.output_ext == '.html'
+
+    output = doc.output
+    return unless output&.match?(%r{\A<link rel="ai:})
+
+    links = output.scan(%r{<link rel="ai:[^"]*"[^>]*>}).join("\n")
+    body = output.sub(%r{\A(?:<link rel="ai:[^"]*"[^>]*>\s*)+}, '')
+
+    doc.output =
+      if body.include?('</head>')
+        body.sub('</head>', "#{links}\n</head>")
+      elsif (html_open = body.match(%r{<!DOCTYPE html>\s*<html([^>]*)>}i))
+        attrs = html_open[1].to_s
+        lang = attrs[/lang="([^"]*)"/i, 1]
+        lang = 'en' if lang.nil? || lang.start_with?('en')
+        body.sub(
+          %r{<!DOCTYPE html>\s*<html[^>]*>}i,
+          "<!DOCTYPE html>\n<html lang=\"#{lang}\">\n<head>\n#{links}\n<meta charset=\"utf-8\">\n</head>"
+        )
+      else
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n#{links}\n</head>\n#{body}"
+      end
+  end
+end
+
+Jekyll::Hooks.register :pages, :post_render, priority: :low do |doc|
+  FixAiLinkDoctypeOrder.fix!(doc)
+end
+
+Jekyll::Hooks.register :documents, :post_render, priority: :low do |doc|
+  FixAiLinkDoctypeOrder.fix!(doc)
+end

--- a/_posts/2024-06-01-imposter-syndrome.md
+++ b/_posts/2024-06-01-imposter-syndrome.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Imposter Syndrome: How Employers Can Use It Against You"
-description: "Discover how imposter syndrome affects tech workers and learn strategies to overcome self-doubt. A personal story of recognizing and overcoming workplace-induced imposter feelings."
+description: "Discover how imposter syndrome affects tech workers and strategies to overcome self-doubt—a personal story of workplace-induced imposter feelings."
 tags: [imposter syndrome, workplace culture, employee well-being, toxic work environment, psychological safety, fear-based management, career development, professional growth, mental health, employee empowerment, ethical employment practices, productivity and innovation, constructive feedback, overcoming self-doubt, personal experience in work сulture]
 author: eugene
 categories: [Self-Knowledge, Mental Health]

--- a/_posts/2026-06-04-the-ai-model-is-no-longer-the-bottleneck.md
+++ b/_posts/2026-06-04-the-ai-model-is-no-longer-the-bottleneck.md
@@ -2,7 +2,7 @@
 layout: post
 title: "The AI Model Is No Longer The Bottleneck"
 last_modified_at: 2026-06-04
-description: "Developers obsess over model benchmarks, but the real productivity gap is in workflows, agent design, and toolchain architecture. Why open systems and workflow-first thinking beat model-chasing."
+description: "Model benchmarks get the attention, but workflows, agent design, and toolchain architecture drive real AI coding productivity. Why workflow-first beats model-chasing."
 tags: [ai, developer tools, ai agents, workflow, opencode, engineering leadership, fractional cto, software architecture, open source, tech strategy, llm, productivity]
 author: eugene
 categories: [AI, Engineering]


### PR DESCRIPTION
Use uppercase DOCTYPE, shorten meta descriptions over 170 characters, keep ai:* link tags after DOCTYPE on redirect pages, and add nasuta author alias.