### PR TITLE
LLM visibility + SEO heading fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -291,7 +291,7 @@ ai_visible_content:
     allow_googlebot: true
     allow_bingbot: true
     custom_rules: []                         # [{user_agent: "Bot", directive: "Allow", path: "/"}]
-    generate_robots_txt: true
+    generate_robots_txt: false
 
   # --- llms.txt ---
   llms_txt:
@@ -341,6 +341,6 @@ ai_visible_content:
     warn_missing_descriptions: true
     fail_build_on_error: false               # true = exit 1 on validation failure
     content_only: true                       # Only validate authored HTML content pages
-    exclude_paths: []                        # Glob patterns to skip: ["/custom/*", "/drafts/*"]
+    exclude_paths: ["/*.md", "/**/*.md", "/*.md.txt", "/**/*.md.txt"]  # Skip generated Markdown files
     verbose: false                           # true = show every warning; false = grouped summary
     max_examples: 3  

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -18,9 +18,9 @@
         <a href="{{ '/' | relative_url }}" aria-label="Go to homepage">{{ site.title }}</a>
       </h1>
     {% else %}
-      <h2 class="site-title">
+      <div class="site-title">
         <a href="{{ '/' | relative_url }}" aria-label="Go to homepage">{{ site.title }}</a>
-      </h2>
+      </div>
     {% endif %}
     <p class="site-subtitle fst-italic mb-0">{{ site.tagline }}</p>
   </header>

--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -6,12 +6,6 @@ layout: page
 {% include lang.html %}
 
 <div id="page-category">
-  <h2 class="ps-lg-2">
-    <i class="far fa-folder-open fa-fw text-muted"></i>
-    {{ page.title }}
-    <span class="lead text-muted ps-2">{{ page.posts | size }}</span>
-  </h2>
-
   <ul class="content ps-0">
     {% for post in page.posts %}
       <li class="d-flex justify-content-between px-md-3">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,7 +9,7 @@ layout: default
 {% endif %}
 
 <article class="px-1">
-  {% if page.layout == 'page' or page.collection == 'tabs' %}
+  {% if page.layout == 'page' or page.layout == 'tag' or page.layout == 'category' or page.collection == 'tabs' %}
     {% assign tab_key = page.title | downcase %}
     {% comment %} Extract tab key from URL if title doesn't match {% endcomment %}
     {% if tab_key == '' or tab_key == nil %}
@@ -18,14 +18,18 @@ layout: default
     {% endif %}
     {% assign base_title = site.data.locales[lang].tabs[tab_key] | default: page.title %}
     {% comment %} Create descriptive titles for SEO (20-70 characters) {% endcomment %}
-    {% if tab_key == 'categories' or page.url contains '/categories/' %}
+    {% if tab_key == 'categories' or page.url == '/categories/' or page.url == '/categories/index.html' %}
       {% assign title = 'Browse All Blog Post Categories - Organized Topics' %}
-    {% elsif tab_key == 'tags' or page.url contains '/tags/' %}
+    {% elsif tab_key == 'tags' or page.url == '/tags/' or page.url == '/tags/index.html' %}
       {% assign title = 'Explore All Blog Tags - Find Posts by Topic' %}
-    {% elsif tab_key == 'archives' or page.url contains '/archives/' %}
+    {% elsif tab_key == 'archives' or page.url == '/archives/' or page.url == '/archives/index.html' %}
       {% assign title = 'Blog Archives - Browse Posts by Date and Year' %}
     {% elsif tab_key contains 'motivation' or page.url contains '/motivation-test/' or page.title contains 'Motivation' %}
       {% assign title = 'Motivation Test - Discover Your Work Motivation Style' %}
+    {% elsif page.url contains '/categories/' %}
+      {% assign title = 'Category: ' | append: page.title %}
+    {% elsif page.url contains '/tags/' %}
+      {% assign title = 'Tag: ' | append: page.title %}
     {% else %}
       {% assign title = base_title %}
     {% endif %}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -6,11 +6,6 @@ layout: page
 {% include lang.html %}
 
 <div id="page-tag">
-  <h2 class="ps-lg-2">
-    <i class="fa fa-tag fa-fw text-muted"></i>
-    {{ page.title }}
-    <span class="lead text-muted ps-2">{{ page.posts | size }}</span>
-  </h2>
   <ul class="content ps-0">
     {% for post in page.posts %}
       <li class="d-flex justify-content-between px-md-3">

--- a/_plugins/llm_visibility.rb
+++ b/_plugins/llm_visibility.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'date'
+
+module Jekyll
+  module LlmVisibility
+    # Generate standard .md routes alongside HTML pages
+    class MdGenerator < Generator
+      safe true
+      priority :low
+
+      def generate(site)
+        config = site.config['ai_visible_content'] || {}
+        return unless config['enabled']
+
+        docs = content_pages(site)
+        docs.each do |doc|
+          md_path = standard_md_path(doc)
+          next unless md_path
+          next if md_path == '/.md'
+
+          # Skip if already generated (e.g. by another plugin or duplicate)
+          next if site.pages.any? { |p| p.data['permalink'] == md_path && p.is_a?(Jekyll::PageWithoutAFile) }
+
+          content = build_page_markdown_content(doc)
+          # Use .txt extension internally so Jekyll doesn't run markdown converter
+          internal_name = md_path.sub(%r{^/}, '').tr('/', '_') + '.txt'
+          page = Jekyll::PageWithoutAFile.new(site, site.source, '', internal_name)
+          page.content = content
+          page.data['layout'] = nil
+          page.data['sitemap'] = false
+          page.data['permalink'] = md_path
+          site.pages << page
+        end
+      end
+      
+      def content_pages(site)
+        docs = site.documents.dup
+        page_pages = site.pages.select do |p|
+          next false unless p.url
+          next false if p.url.start_with?('/assets/')
+          next false if %w[.xml .json .md .txt .yml].include?(File.extname(p.url).downcase)
+          next false if p.is_a?(Jekyll::PageWithoutAFile)
+          true
+        end
+        docs += page_pages
+        docs
+      end
+
+      private
+
+      def standard_md_path(doc)
+        url = doc.url.to_s
+        return '/index.md' if url == '/' || url == '/index.html'
+        return nil if url.empty?
+
+        base = url.chomp('/')
+        return nil if base.empty?
+
+        ext = File.extname(base)
+        if ext.empty?
+          "#{base}.md"
+        else
+          "#{base.chomp(ext)}.md"
+        end
+      end
+
+      def build_page_markdown_content(doc)
+        raw = File.exist?(doc.path) ? File.read(doc.path) : doc.content.to_s
+        front_matter, body = extract_front_matter_and_body(raw)
+        meta = parse_front_matter_hash(front_matter)
+        cleaned_body = strip_liquid_tags(body)
+        heading = meta['title'].to_s.strip
+        description = meta['description'].to_s.strip
+        subtitle = meta['subtitle'].to_s.strip
+
+        lines = []
+        lines << "# #{heading}" unless heading.empty?
+        lines << ''
+        lines << "_#{subtitle}_" unless subtitle.empty?
+        lines << '' unless subtitle.empty?
+        lines << description unless description.empty?
+        lines << '' unless description.empty?
+        lines << cleaned_body
+        built = lines.join("\n").gsub(/\n{3,}/, "\n\n").strip
+        "#{built}\n"
+      end
+
+      def extract_front_matter_and_body(raw)
+        match = raw.match(/\A---\s*\n(.*?)\n---\s*\n?(.*)\z/m)
+        return ['', raw] unless match
+
+        ["#{match[1].rstrip}\n", match[2]]
+      end
+
+      def strip_liquid_tags(content)
+        cleaned = content.to_s
+                         .gsub(/\{%\s*comment\s*%\}.*?\{%\s*endcomment\s*%\}/m, '')
+                         .gsub(/\{%-?\s*.*?\s*-?%\}/m, '')
+                         .gsub(/\{\{\s*.*?\s*\}\}/m, '')
+                         .gsub(/\n{3,}/, "\n\n")
+                         .strip
+        "#{cleaned}\n"
+      end
+
+      def parse_front_matter_hash(front_matter)
+        return {} if front_matter.to_s.strip.empty?
+
+        parsed = YAML.safe_load(front_matter, permitted_classes: [Date, Time], aliases: true)
+        parsed.is_a?(Hash) ? parsed : {}
+      rescue Psych::Exception
+          {}
+      end
+    end
+
+    # Inject <link rel="alternate" type="text/markdown"> into HTML <head>
+    class AlternateLinkInjector
+      def self.process(doc)
+        return unless doc.output_ext == '.html'
+        return unless doc.output
+
+        site = doc.site
+        config = site.config['ai_visible_content'] || {}
+        return unless config['enabled']
+        return if doc.is_a?(Jekyll::PageWithoutAFile)
+
+        md_path = standard_md_path(doc)
+        return unless md_path
+
+        # Avoid duplicate injection
+        return if doc.output.include?('rel="alternate" type="text/markdown"')
+
+        link_tag = %(<link rel="alternate" type="text/markdown" href="#{md_path}">)
+        if doc.output.include?('</head>')
+          doc.output = doc.output.sub('</head>', "#{link_tag}\n</head>")
+        end
+      end
+
+      def self.standard_md_path(doc)
+        url = doc.url.to_s
+        return '/index.md' if url == '/' || url == '/index.html'
+        return nil if url.empty?
+
+        base = url.chomp('/')
+        return nil if base.empty?
+
+        ext = File.extname(base)
+        if ext.empty?
+          "#{base}.md"
+        else
+          "#{base.chomp(ext)}.md"
+        end
+      end
+    end
+
+    # Inject visually-hidden Markdown pointer into HTML <body>
+    class VisuallyHiddenInjector
+      def self.process(doc)
+        return unless doc.output_ext == '.html'
+        return unless doc.output
+
+        site = doc.site
+        config = site.config['ai_visible_content'] || {}
+        return unless config['enabled']
+        return if doc.is_a?(Jekyll::PageWithoutAFile)
+
+        md_path = standard_md_path(doc)
+        return unless md_path
+
+        full_url = "#{site.config['url']}#{md_path}"
+
+        # Avoid duplicate injection
+        return if doc.output.include?('A Markdown version of this page is available')
+
+        pointer = <<~HTML
+          <div style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" aria-hidden="true">
+            A Markdown version of this page is available at #{full_url}.
+          </div>
+        HTML
+
+        if doc.output.include?('</body>')
+          doc.output = doc.output.sub('</body>', "#{pointer}\n</body>")
+        end
+      end
+
+      def self.standard_md_path(doc)
+        url = doc.url.to_s
+        return '/index.md' if url == '/' || url == '/index.html'
+        return nil if url.empty?
+
+        base = url.chomp('/')
+        return nil if base.empty?
+
+        ext = File.extname(base)
+        if ext.empty?
+          "#{base}.md"
+        else
+          "#{base.chomp(ext)}.md"
+        end
+      end
+    end
+  end
+end
+
+Jekyll::Hooks.register(:pages, :post_render) { |page| Jekyll::LlmVisibility::AlternateLinkInjector.process(page) }
+Jekyll::Hooks.register(:documents, :post_render) { |doc| Jekyll::LlmVisibility::AlternateLinkInjector.process(doc) }
+Jekyll::Hooks.register(:pages, :post_render) { |page| Jekyll::LlmVisibility::VisuallyHiddenInjector.process(page) }
+Jekyll::Hooks.register(:documents, :post_render) { |doc| Jekyll::LlmVisibility::VisuallyHiddenInjector.process(doc) }

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,6 @@
+User-agent: *
+Allow: /
+Disallow: /norobots/
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+
+Sitemap: https://madmatvey.github.io/sitemap.xml


### PR DESCRIPTION
- Add robots.txt with Content-Signal directive
- Add _plugins/llm_visibility.rb for standard .md routes
- Add <link rel=alternate type=text/markdown> to HTML pages
- Add visually-hidden Markdown pointers for LLMs
- Fix sidebar site-title to use <div> instead of <h2> on non-home pages
- Fix page.html to generate proper <h1> for tag/category/archive pages
- Remove duplicate <h1> from tag.html and category.html